### PR TITLE
fix: amm-1929 username and passwords are passed plain

### DIFF
--- a/src/app/app-modules/user-login/login/login.component.ts
+++ b/src/app/app-modules/user-login/login/login.component.ts
@@ -197,7 +197,7 @@ export class LoginComponent implements OnInit, OnDestroy {
           res.data.previlegeObj !== undefined &&
           res.data.previlegeObj !== null
         ) {
-          this.getServiceAuthenticationDetails(res.data);
+          this.getServiceAuthenticationDetails(res.data, encryptedPwd);
         } else if (res.statusCode === 5002) {
           if (
             res.errorMessage ===
@@ -257,7 +257,7 @@ export class LoginComponent implements OnInit, OnDestroy {
                         userLoggedIn.data.previlegeObj !== undefined
                       ) {
                         this.loginService.userLoginData = userLoggedIn.data;
-                        this.getServiceAuthenticationDetails(userLoggedIn.data);
+                        this.getServiceAuthenticationDetails(userLoggedIn.data, encryptedPwd);
                       } else {
                         this.resetCaptcha();
                         this.confirmationService.openDialog(
@@ -289,7 +289,7 @@ export class LoginComponent implements OnInit, OnDestroy {
    * @param loginDataResponse
    * Authenticating user have ECD privilege or not
    */
-  getServiceAuthenticationDetails(loginDataResponse: any) {
+  getServiceAuthenticationDetails(loginDataResponse: any, encPassword:any) {
     const servicePrivileges = loginDataResponse.previlegeObj.filter(
       (privilegeResp: any) => {
         if (

--- a/src/app/app-modules/user-login/login/login.component.ts
+++ b/src/app/app-modules/user-login/login/login.component.ts
@@ -343,7 +343,7 @@ export class LoginComponent implements OnInit, OnDestroy {
          */
 
 
-         this.ctiService.getCTILoginToken(this.loginForm.controls.userName.value, this.loginForm.controls.password.value).subscribe((response:any) => {
+         this.ctiService.getCTILoginToken(this.loginForm.controls.userName.value, encPassword).subscribe((response:any) => {
           if(response && response.data) {
           this.loginService.loginKey = response.data.login_key;
           }


### PR DESCRIPTION
## 📋 Description

JIRA ID: [AMM-1929](https://support.piramalfoundation.org/jira/browse/AMM-1929)

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)

## ℹ️ Additional Information
**Summary of changes:**
The fix addresses AMM-1929 security issue where "username and passwords are passed plain" (in plain text). 
By passing the [encryptedPwd] parameter through the authentication chain, the encrypted password can now be used internally within the [getServiceAuthenticationDetails()] method instead of potentially transmitting credentials in plain text. This improves the security of the login process..

**Changes Made:**

The encrypted password is now passed through the authentication flow by adding [encryptedPwd] parameter to two calls of [getServiceAuthenticationDetails()] method and updating its method signature to accept this parameter, ensuring credentials are not transmitted in plain text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal authentication handling to support additional security parameters during login, improving credential management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->