### PR TITLE
fix: amm-2123 submit button disabled on text enter on the send advice

### DIFF
--- a/src/app/app-modules/associate-anm-mo/call-closure/call-closure.component.html
+++ b/src/app/app-modules/associate-anm-mo/call-closure/call-closure.component.html
@@ -239,7 +239,7 @@
                                     class="col-xs-12 col-sm-6 col-md-4 col-lg-4 box m-bottom">
                                     <mat-form-field class="backgroundWhite" appearance="outline" [style.width]="'100%'">
                                         <mat-label>{{currentLanguageSet?.sendAdvice}}</mat-label>
-                                        <textarea minlength="10" maxlength="500" matInput placeholder="" id="sendAdvice"
+                                        <textarea minlength="1" maxlength="500" matInput placeholder="" id="sendAdvice"
                                             formControlName="sendAdvice" type="text" defaultNull></textarea>
                                         <!-- <mat-error *ngIf="callClosureForm.controls['sendAdvice'].errors?.['required']">{{
                                     currentLanguageSet.Advice }}</mat-error>


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

AMM-2123 
---
Under MO - Submit button gets disabled after entering text in Send Advice(Regression Issue)

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)

---

## ℹ️ Additional Information

Due to minlenght attribute validation, the submit button gets disabled. It was expecting a minimum of 10 characters to be entered. 
Fix: set minlenght = 1.