### PR TITLE
fix: changes made for outbound worklist navigation issue

### DIFF
--- a/src/app/app-modules/associate-anm-mo/agents-innerpage/agents-innerpage.component.ts
+++ b/src/app/app-modules/associate-anm-mo/agents-innerpage/agents-innerpage.component.ts
@@ -628,19 +628,22 @@ export class AgentsInnerpageComponent implements OnInit, DoCheck, OnDestroy {
   }
 
 
-
-  getAgentState() {
-    const reqObj = {"agent_id" : this.loginService.agentId};
-    this.ctiService.getAgentState(reqObj).subscribe((response:any) => {
-        if (response && response.data && response.data.stateObj.stateName) {
-            this.agentStatus = response.data.stateObj.stateName;
-            this.associateAnmMoService.setAgentState(this.agentStatus);
-        }
-
-    }, (err) => {
-       console.log("error");
-    });
-}
+getAgentState() {  
+  const reqObj = {"agent_id" : this.loginService.agentId};  
+  this.ctiService.getAgentState(reqObj).subscribe((response:any) => {  
+    if (response && response.data && response.data.stateObj.stateName) {  
+      const previousStatus = this.agentStatus;  
+      this.agentStatus = response.data.stateObj.stateName;  
+      this.associateAnmMoService.setAgentState(this.agentStatus);  
+        
+      // Navigate when transitioning to INCALL after call initiation  
+      if (this.associateAnmMoService.isCallInitiated && previousStatus !== "INCALL" && this.agentStatus === "INCALL") {  
+        this.viewBenRegScreen();  
+        this.associateAnmMoService.setCallInitiated(false);
+      }  
+    }  
+  });  
+}  
 
   getAgentIpAddress() {
     const reqObj={

--- a/src/app/app-modules/associate-anm-mo/outbound-worklist/outbound-worklist.component.ts
+++ b/src/app/app-modules/associate-anm-mo/outbound-worklist/outbound-worklist.component.ts
@@ -63,6 +63,7 @@ export class OutboundWorklistComponent implements OnInit, DoCheck, AfterViewInit
   isAutoPreviewDial = false;
   previewWindowTime: any;
   agentStatus: any;
+  callInitiated = false;  
   autoPreviewTimeSub: Subscription = new Subscription;
   autoCallStarted: any = false
   showPrompt = false;
@@ -378,6 +379,8 @@ export class OutboundWorklistComponent implements OnInit, DoCheck, AfterViewInit
 
                       this.sessionstorage.setItem("onCall", "true");
                       this.associateAnmMoService.setBenRegistartionComp(true);
+                      this.callInitiated = true;
+                      this.associateAnmMoService.setCallInitiated(true);
                     }
                     else {
                       this.confirmationService.openDialog(response.errorMessage, 'error');
@@ -406,6 +409,7 @@ export class OutboundWorklistComponent implements OnInit, DoCheck, AfterViewInit
 
                 this.sessionstorage.setItem("onCall", "true");
                 this.associateAnmMoService.setBenRegistartionComp(true);
+                this.callInitiated = true;
               }
             },
             (err: any) => {

--- a/src/app/app-modules/services/associate-anm-mo/associate-anm-mo.service.ts
+++ b/src/app/app-modules/services/associate-anm-mo/associate-anm-mo.service.ts
@@ -40,6 +40,7 @@ export class AssociateAnmMoService {
   isHighRiskPregnancy = false;
   isHighRiskInfant = false;
   autoDialing = false;
+  isCallInitiated = false; 
 
   callWrapup: any = "";
   callWrapupFlag = new BehaviorSubject(this.callWrapup);
@@ -267,4 +268,9 @@ export class AssociateAnmMoService {
   updateCallStatus(reqObj: any) {
     return this.http.post(environment.updateCallStatusAPI, reqObj);
   }
+
+  setCallInitiated(value: boolean) {  
+    this.isCallInitiated = value;
+  }
+
 }


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

After clicking the call icon in the Outbound Worklist, the app was not navigating to the Beneficiary Registration screen consistently. The navigation depended on the Czentrix CTI system sending an "Accept" event, which only fires after the Czentrix SDK fully loads. On slow networks, this took 30+ seconds or never happened at all, causing the page to stay on the Outbound Worklist.

Fix: Instead of waiting for the Czentrix Accept event, we now poll our own getAgentState API every 15 seconds. When the agent status transitions to INCALL after a call is initiated, navigation to Beneficiary Registration is triggered immediately without depending on Czentrix SDK timing.
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
