### PR TITLE
fix: enhance UI error handling with HTTP codes

### DIFF
--- a/src/app/app-modules/services/http-inteceptor/http-interceptor.service.ts
+++ b/src/app/app-modules/services/http-inteceptor/http-interceptor.service.ts
@@ -85,25 +85,48 @@ export class HttpInterceptorService implements HttpInterceptor {
       catchError((error: HttpErrorResponse) => {
         console.error(error);
         this.spinnerService.setLoading(false);
-        return throwError(error.error);
+        const silent404Apis = ['getCSatScoreByPSMIdAndFrequency'];         
+        const isSilent404 = silent404Apis.some(api => req.url.includes(api));
+
+        if (error.status === 404 && isSilent404) {
+          return throwError(error);
+        }
+
+        const isLoginUrl = req.url.includes('user/userAuthenticate');
+        let errorMessage = 'Something went wrong';
+
+        if (error.error && error.error.message) {
+          errorMessage = error.error.message;
+        } else if (error.message) {
+          errorMessage = error.message;
+        }
+
+        if (error.status === 401 || error.status === 403) {
+          if (!isLoginUrl) {
+            this.sessionstorage.clear();
+            sessionStorage.clear();
+            localStorage.clear();
+            this.confirmationService.openDialog(error.status === 401 ? 'Session expired, Please login again' : 'Access denied', 'error');
+            this.router.navigate(['/login']);
+          } else {
+            this.confirmationService.openDialog('Invalid credentials', 'error');
+          }
+        } else if (error.status === 400) {
+          this.confirmationService.openDialog(errorMessage, 'error');
+        } else if (error.status >= 500) {
+          this.confirmationService.openDialog('Server error. Please try again later.', 'error');
+        } else {
+          this.confirmationService.openDialog(errorMessage, 'error');
+        }
+
+        return throwError(error);
       })
     );
   }
 
   private onSuccess(url: string, response: any): void {
     if (this.timerRef) clearTimeout(this.timerRef);
-
-    if (
-      response.statusCode === 5002 &&
-      url.indexOf('user/userAuthenticate') < 0
-    ) {
-      sessionStorage.clear();
-      localStorage.clear();
-      setTimeout(() => this.router.navigate(['/login']), 0);
-      this.confirmationService.openDialog(response.errorMessage, 'error');
-    } else {
-      this.startTimer();
-    }
+    this.startTimer();
   }
 
   startTimer() {

--- a/src/app/app-modules/services/http-inteceptor/http-interceptor.service.ts
+++ b/src/app/app-modules/services/http-inteceptor/http-interceptor.service.ts
@@ -126,7 +126,20 @@ export class HttpInterceptorService implements HttpInterceptor {
 
   private onSuccess(url: string, response: any): void {
     if (this.timerRef) clearTimeout(this.timerRef);
-    this.startTimer();
+    
+
+    if (
+      response && 
+      response.statusCode === 5002 &&
+      url.indexOf('user/userAuthenticate') < 0
+    ) {
+      sessionStorage.clear();
+      localStorage.clear();
+      setTimeout(() => this.router.navigate(['/login']), 0);
+      this.confirmationService.openDialog(response.errorMessage || 'Session expired, Please login again', 'error');
+    } else {
+      this.startTimer();
+    }
   }
 
   startTimer() {


### PR DESCRIPTION
## 📋 Description

JIRA ID: PSMRI/AMRIT#113


Because the backend (`ECD-API`) is being updated to return proper REST HTTP status codes (400, 401, 500) instead of hiding errors inside a `200 OK` response, our frontend HTTP Interceptor needed to be updated to catch these new responses correctly.

This PR refactors `http-interceptor.service.ts`:
- Removed the legacy check for custom internal status codes (like `5002`) inside successful responses.
- Enhanced the `catchError` pipeline to properly intercept standard `HttpErrorResponse` objects.
- It now cleanly wipes `sessionStorage` and redirects to the login page on `401 Unauthorized` or `403 Forbidden` errors.
- It maps standard `400` validation errors and `500` server errors to our user-friendly dialogue popups.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

**Testing & Context:**
- Built the frontend locally (`ng build --configuration=production`) to ensure the updated interceptor didn't introduce any strict TypeScript typing errors.
- The `catchError` logic was streamlined using standard `if/else` checks and an `Array.some()` method for excluded endpoints to keep the interceptor fast and performant. 
- Ensure that the companion PR in `ECD-API` is merged, as this UI update directly relies on the backend returning standard HTTP codes.
